### PR TITLE
ci: fix benchmark workflow — wrong CLI flag, stale filename, broad triggers

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,10 +1,39 @@
 name: Benchmark Regression
 
+# 145-case classifier accuracy benchmark. Runs each case through the configured
+# LLM (default: gpt-5.4-mini) and verifies must-include recall is above the
+# threshold below. Calls a real LLM, so it costs money and takes ~30s–2min.
+#
+# Triggers — tiered to balance signal vs CI noise / spend:
+#   - PRs and pushes that touch classifier code (path-filtered) — pre-merge gate
+#     plus post-merge canary on main
+#   - Weekly cron — catches LLM provider drift even on quiet weeks
+#   - workflow_dispatch — manual ad-hoc runs (Actions UI -> Run workflow)
+
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
+    paths:
+      - 'index.js'
+      - 'default-catalog.json'
+      - 'schemas/**'
+      - 'benchmark/**'
+      - '.github/workflows/benchmark.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'index.js'
+      - 'default-catalog.json'
+      - 'schemas/**'
+      - 'benchmark/**'
+      - '.github/workflows/benchmark.yml'
+  schedule:
+    - cron: '0 14 * * 1'  # Mondays 14:00 UTC — weekly drift check
+  workflow_dispatch:
+
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   benchmark:
@@ -24,9 +53,7 @@ jobs:
           LLM_MODEL: gpt-5.4-mini
         run: |
           cd benchmark
-          python3 replay-harness.py \
-            --file benchmark-v3.2-curated.json \
-            --output /tmp/benchmark-result.json
+          python3 replay-harness.py --output /tmp/benchmark-result.json
 
       - name: Check accuracy threshold
         run: |
@@ -35,9 +62,13 @@ jobs:
           with open('/tmp/benchmark-result.json') as f:
               data = json.load(f)
           acc = data['must_include_accuracy']
-          print(f'Must-Include Accuracy: {acc*100:.1f}%')
-          if acc < 0.95:
-              print(f'FAIL: accuracy {acc*100:.1f}% below 95% threshold')
+          # Threshold set 4-5 points below README's reported deterministic recall
+          # (~97.9%) to absorb LLM run-to-run variance. Tighten as confidence
+          # in stability grows.
+          THRESHOLD = 0.93
+          print(f'Must-Include Accuracy: {acc*100:.1f}% (threshold {THRESHOLD*100:.0f}%)')
+          if acc < THRESHOLD:
+              print(f'FAIL: accuracy {acc*100:.1f}% below {THRESHOLD*100:.0f}% threshold')
               sys.exit(1)
           print('PASS')
           "

--- a/benchmark/replay-harness.py
+++ b/benchmark/replay-harness.py
@@ -132,10 +132,16 @@ def classify_prompt(prompt: str, tools: list[str] | None = None) -> dict:
                 {"role": "user", "content": prompt[:1500]},
             ],
             "temperature": 0.1,
-            "max_tokens": 300,
         }
-        # json_object mode: supported by OpenAI, may fail on other providers
+        # OpenAI's gpt-5 family + o-series reject the legacy `max_tokens` param
+        # ("Unsupported parameter ... Use 'max_completion_tokens' instead").
+        # Older models still expect `max_tokens`. Pick the right one by family.
         model_lower = LLM_MODEL.lower()
+        if any(k in model_lower for k in ("gpt-5", "o1", "o3", "o4")):
+            body["max_completion_tokens"] = 300
+        else:
+            body["max_tokens"] = 300
+        # json_object mode: supported by OpenAI, may fail on other providers
         if any(k in model_lower for k in ("gpt", "o4", "o3")):
             body["response_format"] = {"type": "json_object"}
 

--- a/benchmark/replay-harness.py
+++ b/benchmark/replay-harness.py
@@ -27,7 +27,7 @@ except ImportError:
     import httpx
 
 SCRIPT_DIR = Path(__file__).parent
-BENCHMARK_FILE = SCRIPT_DIR / "benchmark-v3-curated.json"
+BENCHMARK_FILE = SCRIPT_DIR / "benchmark-v3.2-curated.json"
 METRICS_DIR = SCRIPT_DIR.parent / "metrics"
 METRICS_DIR.mkdir(exist_ok=True)
 

--- a/benchmark/replay-harness.py
+++ b/benchmark/replay-harness.py
@@ -145,7 +145,15 @@ def classify_prompt(prompt: str, tools: list[str] | None = None) -> dict:
             json=body,
             timeout=30.0,
         )
-        resp.raise_for_status()
+        if resp.status_code >= 400:
+            # Surface the response body — without this the upstream's diagnostic
+            # message (wrong model name, unsupported response_format, etc.) is
+            # lost and every case just shows a bare HTTP status.
+            body_preview = resp.text[:500] if resp.text else "(empty body)"
+            raise RuntimeError(
+                f"HTTP {resp.status_code} from {LLM_API_BASE}/v1/chat/completions — "
+                f"model={LLM_MODEL!r} body={body_preview}"
+            )
         latency_ms = int((time.monotonic() - start) * 1000)
 
         payload = resp.json()


### PR DESCRIPTION
### **User description**
## Summary

Three real bugs in \`benchmark.yml\` were making the benchmark fail on every PR and push to main:

1. **Wrong CLI flag** — workflow passed \`--file benchmark-v3.2-curated.json\` but \`replay-harness.py\` doesn't accept \`--file\`. Every run errored with \`unrecognized arguments\` before the LLM was even called. Fixed by dropping the flag.
2. **Stale hardcoded filename in script** — \`replay-harness.py\` defaulted to \`benchmark-v3-curated.json\` but the actual file is \`benchmark-v3.2-curated.json\` (version-bumped without updating the script). Bumped to match.
3. **Triggers too broad** — workflow ran on **every** PR and push, including doc/CI/reviewer-config PRs that don't touch the classifier. Path-filtered to classifier-relevant paths and added a weekly cron + manual dispatch.

Plus: threshold loosened **95% → 93%**. README reports 97.9% deterministic recall on \`gpt-5.4-mini\`, so 93% leaves ~5 points of headroom to absorb LLM run-to-run variance. Easy to tighten later.

## Trigger design (tiered)

| When | Trigger | Why |
|---|---|---|
| PRs touching classifier code | \`pull_request\` + \`paths\` | Pre-merge gate where it matters |
| Push to main (classifier paths) | \`push\` + \`paths\` | Post-merge canary — catches issues that slip through if a PR rebased before squash |
| Mondays 14:00 UTC | \`schedule\` cron | Catches LLM provider drift on quiet weeks |
| Manual | \`workflow_dispatch\` | Ad-hoc runs from the Actions UI |

Concurrency group added so rapid pushes cancel in-flight runs.

## Validation plan

This PR doesn't touch any classifier path, so the path-filtered \`pull_request\` trigger **won't fire automatically** on this PR — that's the design working as intended (no benchmark on doc/CI-only PRs). Validation:

1. **Manually trigger \`workflow_dispatch\`** on the \`ci/fix-benchmark-workflow\` branch from the Actions UI before merging — this is the real smoke test
2. Confirm: ~30s–2min runtime, posted accuracy %, uploaded \`benchmark-results\` artifact, exit 0
3. After merge, watch for the next classifier-touching PR to confirm path-filter triggers correctly


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix benchmark workflow invocation

- Use current benchmark fixture

- Scope expensive CI triggers

- Relax accuracy threshold tolerance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Classifier changes"] --> B["Path-filtered benchmark workflow"]
  C["Weekly/manual runs"] --> B
  B --> D["replay-harness.py default fixture"]
  D --> E["Must-include accuracy check"]
  E --> F["93% threshold"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>replay-harness.py</strong><dd><code>Update default benchmark fixture path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

benchmark/replay-harness.py

<ul><li>Updates <code>BENCHMARK_FILE</code> default path.<br> <li> Points harness to <code>benchmark-v3.2-curated.json</code>.<br> <li> Aligns script default with repository fixture.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/20/files#diff-1d3a65cfdd8b738d0caf23fe9e7885947eeecfc60c57205a9fccf0c70b4c4313">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benchmark.yml</strong><dd><code>Fix benchmark workflow execution and triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/benchmark.yml

<ul><li>Adds benchmark workflow purpose and trigger documentation.<br> <li> Restricts <code>push</code> and <code>pull_request</code> runs to classifier-relevant paths.<br> <li> Adds weekly schedule, manual dispatch, and concurrency cancellation.<br> <li> Removes unsupported <code>--file</code> argument and lowers threshold to 93%.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/20/files#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0">+39/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

