### PR TITLE
ci: harden reviewers — issue_comment fork guard, slash-only, timeouts, reopened

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,7 +9,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 # Cancel in-flight reviews on rapid pushes (avoids duplicate Claude comments
 # and double API spend when commits land in quick succession).
@@ -27,6 +27,7 @@ jobs:
     name: Claude Code Auditor
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 20  # bounds blast radius if a --max-turns 30 session stalls
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gpt-review.yml
+++ b/.github/workflows/gpt-review.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   issue_comment:
+    types: [created]  # don't fire on edit/delete
 
 # Cancel in-flight runs on rapid pushes / repeated `/review` comments.
 concurrency:
@@ -29,11 +30,22 @@ permissions:
 jobs:
   pr_agent:
     name: GPT-5.5 Code Review
+    # Two-layer guard:
+    # - pull_request: skip PRs from forks (secrets aren't exposed there)
+    # - issue_comment: must be (a) on a PR, (b) a slash command (pr-agent's
+    #   only recognized inputs), AND (c) from a trusted association so
+    #   external contributors can't burn API quota or expose this
+    #   secret-bearing workflow to untrusted prompt injection by commenting
+    #   on a fork PR.
     if: >
       (github.event_name == 'pull_request' &&
        github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/') &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Run pr-agent (GPT-5.5)
         # Pinned to SHA of v0.34 — `@main` runs whatever is on the upstream


### PR DESCRIPTION
### **User description**
## Summary

Round-2 hardening for the Claude + GPT-5.5 PR reviewers, carrying over findings from the AI-bot review of [`stroupaloop/openclaw#1`](https://github.com/stroupaloop/openclaw/pull/1) (same workflow templates, same gaps in this repo).

| # | Fix | Severity | File |
|---|---|---|---|
| 1 | `issue_comment` branch had **no fork-PR guard** — external contributors commenting on a fork PR could trigger pr-agent with `PR_AGENT_OPENAI_API_KEY` and write `GITHUB_TOKEN`. Now requires (a) slash-command prefix AND (b) trusted author association (`OWNER`/`MEMBER`/`COLLABORATOR`). | **P1 security** | gpt-review.yml |
| 2 | Slash-command filter also avoids spinning a runner for every regular PR comment. | P2 cost | gpt-review.yml |
| 3 | `timeout-minutes: 20` on both jobs — bounds runaway spend if a `--max-turns 30` session stalls (GH default cap is 6h). | P2 cost | both |
| 4 | Added `reopened` to `claude-review.yml` pull_request types for parity with `gpt-review.yml`. | P3 | claude-review.yml |
| 5 | Restricted `issue_comment` to `types: [created]` so we don't fire on edits/deletes. | P3 | gpt-review.yml |

## Test plan

Same self-validation gotcha as previous rounds — Claude/pr-agent on this PR may trip the workflow-validation block since they modify their own definitions. Real validation is the next normal PR after merge.

- [ ] Diff sanity (~15 lines, both workflow files)
- [ ] Merge despite expected self-validation Claude fail
- [ ] On next normal PR, confirm both reviewers post real comments and that `issue_comment` runs only fire on slash commands


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Harden reviewer workflow trigger conditions

- Require trusted slash-command comments

- Add timeouts to bound CI spend

- Review reopened pull requests too


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pr["Pull request events"]
  comment["Issue comment events"]
  guards["Fork, slash-command, trusted-user guards"]
  reviewers["AI reviewer jobs"]
  timeout["20-minute timeout"]

  pr -- "opened/synchronize/reopened" --> guards
  comment -- "created slash command" --> guards
  guards -- "allowed only" --> reviewers
  reviewers -- "bounded by" --> timeout
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-review.yml</strong><dd><code>Add Claude review reopen trigger and timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-review.yml

<ul><li>Adds <code>reopened</code> to Claude review PR triggers.<br> <li> Adds <code>timeout-minutes: 20</code> to the Claude review job.<br> <li> Documents timeout intent for stalled long-running sessions.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/21/files#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gpt-review.yml</strong><dd><code>Secure GPT reviewer comment triggers and runtime</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gpt-review.yml

<ul><li>Restricts <code>issue_comment</code> workflow triggers to <code>created</code> events.<br> <li> Requires PR comments to be slash commands.<br> <li> Limits comment-triggered runs to trusted author associations.<br> <li> Adds <code>timeout-minutes: 20</code> for the GPT review job.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/21/files#diff-ad1cbaf366d2b784915337d6148f55ea26e85d074d45c3c8d147611acf2f2048">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

