### PR TITLE
ci: pin actions to SHAs + CODEOWNERS for workflow files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Single-maintainer project. Catch-all keeps every PR routed to @stroupaloop.
+* @stroupaloop
+
+# Workflow files have access to repo secrets — call out explicitly so the
+# requirement survives any future override of the catch-all.
+/.github/workflows/ @stroupaloop
+/.github/dependabot.yml @stroupaloop

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Auto-bump GitHub Actions pinned to SHAs in our workflow files.
+# Dependabot opens PRs comparing the SHA + version comment so the diff is
+# reviewable. Monthly cadence keeps churn low.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: scope

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,10 +39,10 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-results
           path: /tmp/benchmark-result.json

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20  # bounds blast radius if a --max-turns 30 session stalls
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Claude Code review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@a9ac9eb3a874922a7e34246afae3914113c6626f # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |


### PR DESCRIPTION
### **User description**
## Summary

Tier-1 supply-chain + governance hardening, paired with the branch-protection rules already enabled on main.

| What | Why |
|---|---|
| **Pin `actions/checkout@v4` and `anthropics/claude-code-action@v1` to SHAs** in our reviewer workflows (matches existing pin on `Codium-ai/pr-agent`) | Tags are mutable refs the maintainer can force-push; SHAs make workflow content reproducible and force a deliberate diff review when bumping |
| **Add `.github/dependabot.yml`** (`github-actions` ecosystem, monthly cadence) | Surface SHA bumps as PRs so we never silently drift, but don't blast CI with daily noise |
| **CODEOWNERS** requires owner review on `.github/workflows/` and `.github/dependabot.yml` | Workflow files have access to all repo secrets — any change should route through explicit approval, not slip through on a self-merge |

## Per-repo notes

- **mission-control (fork)**: appended fork-only CODEOWNERS overrides at end (last-match-wins beats the upstream `* @0xNyk` catch-all for these specific paths only)
- **ender-stack**: CODEOWNERS already covers `/.github/workflows/ @stroupaloop` from PR #97 era — only adding the dependabot.yml + SHA pins here
- **openclaw-resolver**: created CODEOWNERS from scratch (single-maintainer catch-all + explicit workflow rules)
- **openclaw (fork)**: added narrow rules for ONLY `claude-review.yml` and `gpt-review.yml`. Deliberately did NOT add a blanket `/.github/workflows/` rule — that would silently strip the existing `@openclaw/secops` requirement on workflows like `codeql.yml` per the last-match-wins warning at the top of upstream's CODEOWNERS. Also did NOT touch `dependabot.yml` (it's `@openclaw/secops`-protected upstream).

## Test plan

- [ ] Diff sanity per repo (small — actions SHAs + comment, CODEOWNERS additions, dependabot.yml)
- [ ] Merge — Claude self-validation block applies as usual since we touched claude-review.yml; expected fail
- [ ] After merge, watch for the first Dependabot PR (within ~30 days) to confirm it picks up the github-actions ecosystem


___

### **PR Type**
Enhancement


___

### **Description**
- Harden GitHub Actions supply chain

- Add Dependabot action SHA updates

- Require ownership for workflow changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions workflows"] -- "pin actions" --> B["Immutable SHA references"]
  B -- "monthly updates" --> C["Dependabot PRs"]
  D["CODEOWNERS"] -- "requires review" --> A
  D -- "protects" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CODEOWNERS</strong><dd><code>Add CODEOWNERS governance for workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/CODEOWNERS

<ul><li>Adds <code>@stroupaloop</code> as repository catch-all owner.<br> <li> Explicitly protects <code>.github/workflows/</code> changes.<br> <li> Explicitly protects <code>.github/dependabot.yml</code> changes.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/22/files#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Configure Dependabot for GitHub Actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Adds Dependabot configuration for <code>github-actions</code>.<br> <li> Schedules monthly update checks from repository root.<br> <li> Limits open PRs to five.<br> <li> Sets <code>ci</code> commit prefix with scope.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/22/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>benchmark.yml</strong><dd><code>Pin benchmark workflow action SHAs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/benchmark.yml

<ul><li>Pins <code>actions/checkout</code> to a specific SHA.<br> <li> Pins <code>actions/setup-python</code> to a specific SHA.<br> <li> Pins <code>actions/upload-artifact</code> to a specific SHA.<br> <li> Keeps version comments for reviewability.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/22/files#diff-aacbd0338bcf598920c120b69adaba2672acc7ea314cfca0f792bebe5fe2acd0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>claude-review.yml</strong><dd><code>Pin Claude review workflow actions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-review.yml

<ul><li>Pins <code>actions/checkout</code> to a specific SHA.<br> <li> Pins <code>anthropics/claude-code-action</code> to a specific SHA.<br> <li> Keeps version comments beside pinned references.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/22/files#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

