### PR TITLE
fix(ci): stop GPT-5.5 review from being cancelled by every PR comment

### DIFF
--- a/.github/workflows/gpt-review.yml
+++ b/.github/workflows/gpt-review.yml
@@ -18,8 +18,32 @@ on:
     types: [created]  # don't fire on edit/delete
 
 # Cancel in-flight runs on rapid pushes / repeated `/review` comments.
+#
+# Subtlety: this workflow also fires on every `issue_comment.created` event
+# (so slash commands re-run pr-agent). The job-level `if:` below filters
+# non-slash comments out, so they exit immediately — but concurrency is
+# evaluated *before* the job-level `if:`, which means a plain PR comment
+# would still enter the shared group and cancel the in-flight push-triggered
+# review (which is the one we want to keep). Rapid PR discussion would
+# silently kill every review.
+#
+# Fix: route non-slash comments to a unique-per-run noop group so they
+# only collide with themselves. Push events and slash-command comments
+# stay in the shared `gpt-review-${PR}` group where cancel-in-progress
+# does the right thing — newer pushes / explicit /review re-runs cancel
+# stale in-flight reviews against an outdated diff.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
+  group: >-
+    ${{
+      github.event_name == 'issue_comment' &&
+      !startsWith(github.event.comment.body, '/') &&
+      format('gpt-review-noop-{0}', github.run_id)
+      ||
+      format(
+        'gpt-review-{0}',
+        github.event.pull_request.number || github.event.issue.number || github.run_id
+      )
+    }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
### **User description**
## Summary

Ports the concurrency fix from mission-control PR #28 to openclaw-resolver.

**Bug:** `concurrency:` is evaluated *before* the job-level `if:`, so plain PR comments enter the shared `gpt-review-${PR}` group and with `cancel-in-progress: true` — they silently kill the in-flight GPT-5.5 review. The comment then immediately skips itself via the `if:` guard. Net effect: every plain comment wipes the review.

**Fix:** Route non-slash `issue_comment` events to a unique-per-run noop group (`gpt-review-noop-${run_id}`). They only collide with themselves. Push events and `/review` slash commands stay in the shared `gpt-review-${PR}` group — newer pushes still correctly cancel stale reviews against outdated diffs.

| Event | Concurrency group | Cancels in-flight push run? |
|---|---|---|
| `pull_request` (push to PR branch) | `gpt-review-${PR}` | ✅ yes (intended) |
| `issue_comment` slash command | `gpt-review-${PR}` | ✅ yes (intended) |
| `issue_comment` plain comment | `gpt-review-noop-${run_id}` | ❌ no (this was the bug) |

## Related
- mission-control PR #28 (origin of this fix)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent plain comments cancelling reviews

- Preserve cancellation for pushes and `/review`

- Document concurrency evaluation behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR event"] -- "push or /review" --> B["shared gpt-review group"]
  C["Plain issue comment"] -- "non-slash" --> D["unique noop group"]
  B -- "cancels stale runs" --> E["GPT review workflow"]
  D -- "does not cancel" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gpt-review.yml</strong><dd><code>Fix review workflow comment concurrency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gpt-review.yml

<ul><li>Adds explanatory comments about concurrency ordering.<br> <li> Routes non-slash <code>issue_comment</code> events to <code>gpt-review-noop-{run_id}</code>.<br> <li> Keeps PR pushes and slash commands in shared <code>gpt-review-{PR}</code> groups.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/29/files#diff-ad1cbaf366d2b784915337d6148f55ea26e85d074d45c3c8d147611acf2f2048">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

