### PR TITLE
ci(claude-review): raise --max-turns 30→120, timeout 20→40min

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,7 +27,7 @@ jobs:
     name: Claude Code Auditor
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 20  # bounds blast radius if a --max-turns 30 session stalls
+    timeout-minutes: 40  # bounds blast radius if a --max-turns 120 session stalls
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -39,7 +39,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 30
+            --max-turns 120
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
### **User description**
## Problem
30 turns was insufficient for larger PRs. Claude exhausted its turn budget after posting the review but before cleanup, causing CI to exit code 1 — review was delivered but check showed red.

## Fix
- --max-turns 30 → 120 (4x headroom)
- timeout-minutes: 20 → 40

## Why 120 not 240
120 covers all PRs observed to date. Substantive review happens in the first ~40 turns. Worst-case cost at 120 turns is ~$0.50/run.


___

### **PR Type**
Enhancement


___

### **Description**
- Increase Claude review turn budget

- Extend workflow timeout accordingly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  workflow["Claude review workflow"]
  turns["--max-turns 120"]
  timeout["40 minute timeout"]
  workflow -- "allows longer sessions" --> turns
  turns -- "requires larger guardrail" --> timeout
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude-review.yml</strong><dd><code>Increase Claude review CI limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude-review.yml

<ul><li>Raises Claude Code review <code>--max-turns</code> from 30 to 120.<br> <li> Extends the job timeout from 20 to 40 minutes.<br> <li> Updates the timeout comment to match the new turn budget.</ul>


</details>


  </td>
  <td><a href="https://github.com/stroupaloop/openclaw-resolver/pull/30/files#diff-a16b9cfdaf9b59acd95f3f8af7be93c559d14c7e581e809acdc53106fb73971e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

